### PR TITLE
Fix Alpaca endpoints and add snapshots

### DIFF
--- a/src/bin/test_websocket.rs
+++ b/src/bin/test_websocket.rs
@@ -5,27 +5,22 @@ use tokio::time::{sleep, Duration};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Load configuration from environment variables
     let config = Config::from_env()?;
     config.init_logging()?;
 
-    // Create WebSocket client
     let client = WebSocketClient::new(config.alpaca);
 
-    // Connect to WebSocket with some option symbols
-    // Replace these with actual option symbols
+    // Connect to WebSocket with example option symbols
     let symbols = vec![
         "AAPL230616C00180000".to_string(),
         "AAPL230616P00180000".to_string(),
     ];
     client.connect(symbols).await?;
 
-    // Process option quotes
     println!("Waiting for option quotes...");
     let mut count = 0;
     let start = std::time::Instant::now();
 
-    // Process quotes for 10 seconds
     while start.elapsed().as_secs() < 10 {
         if let Some(quote) = client.next_option_quote().await? {
             count += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ use tokio::time::error::Elapsed;
 fn parse_options_chain(data: &Value) -> Result<Vec<OptionContract>> {
     let mut options = Vec::new();
 
-    // Extract options data from the JSON response
     if let Some(results) = data.get("results") {
         if let Some(results_array) = results.as_array() {
             for option_data in results_array {
@@ -32,15 +31,12 @@ fn parse_options_chain(data: &Value) -> Result<Vec<OptionContract>> {
                     option_data.get("strike_price").and_then(|p| p.as_f64()),
                     option_data.get("expiration_date").and_then(|d| d.as_str()),
                 ) {
-                    // Parse expiration date
                     if let Ok(exp_date) = chrono::DateTime::parse_from_rfc3339(expiration) {
                         let exp_utc = exp_date.with_timezone(&chrono::Utc);
-
-                        // Create option contract
                         let option_type = match option_type {
                             "call" => options_rs::models::OptionType::Call,
                             "put" => options_rs::models::OptionType::Put,
-                            _ => continue, // Skip unknown option types
+                            _ => continue,
                         };
 
                         let contract = OptionContract::new(
@@ -63,27 +59,22 @@ fn parse_options_chain(data: &Value) -> Result<Vec<OptionContract>> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Step 1: Load configuration from environment variables
     let config = Config::from_env()?;
     config.init_logging()?;
 
     info!("Starting options-rs example application");
 
-    // Step 2: Create API clients
     let rest_client = RestClient::new(config.alpaca.clone());
     let ws_client = WebSocketClient::new(config.alpaca.clone());
 
-    // Step 3: Get account information
     let account = rest_client.get_account().await?;
     info!("Account: {} (${:.2})", account.id, account.equity);
 
-    // Step 4: Choose a symbol and get available options
     let symbol = "AAPL"; // Example: Apple Inc.
     info!("Getting options for {}", symbol);
 
     let options_data = rest_client.get_options_chain(symbol, None).await?;
 
-    // Parse options data into OptionContract objects
     let options = parse_options_chain(&options_data)?;
     info!("Found {} options for {}", options.len(), symbol);
 
@@ -92,7 +83,6 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Step 5: Extract option symbols for WebSocket subscription
     let option_symbols: Vec<String> = options.iter()
         .map(|opt| opt.symbol.clone())
         .take(50) // Limit to 50 options for this example
@@ -100,10 +90,8 @@ async fn main() -> Result<()> {
 
     info!("Connecting to WebSocket for {} option symbols", option_symbols.len());
 
-    // Step 6: Connect to WebSocket and subscribe to option data
     ws_client.connect(option_symbols).await?;
 
-    // Step 7: Process option quotes and calculate implied volatility
     info!("Processing option quotes and calculating implied volatility");
 
     let mut ivs = Vec::new();
@@ -111,21 +99,17 @@ async fn main() -> Result<()> {
     let max_quotes = 100; // Process up to 100 quotes
     let mut quotes_processed = 0;
 
-    // Create a map to store the latest quote for each option
     let mut latest_quotes = HashMap::new();
 
-    // Process quotes until we have enough data or timeout
     let timeout = tokio::time::Duration::from_secs(30);
     let start_time = std::time::Instant::now();
 
     while quotes_processed < max_quotes && start_time.elapsed() < timeout {
-        // Get the next quote with a timeout
         match tokio::time::timeout(
             tokio::time::Duration::from_secs(1),
             ws_client.next_option_quote(),
         ).await {
             Ok(Ok(Some(quote))) => {
-                // Store the latest quote for each option
                 latest_quotes.insert(quote.contract.option_symbol.clone(), quote.clone());
                 quotes_processed += 1;
 
@@ -133,22 +117,16 @@ async fn main() -> Result<()> {
                     info!("Processed {} quotes", quotes_processed);
                 }
             },
-            Ok(Ok(None)) => {
-                // No quote received, continue
-            },
+            Ok(Ok(None)) => {},
             Ok(Err(e)) => {
-                // Error from next_option_quote
                 return Err(e);
             },
-            Err(_) => {
-                // Timeout, continue
-            }
+            Err(_) => {}
         }
     }
 
     info!("Received {} unique option quotes", latest_quotes.len());
 
-    // Calculate implied volatility for each quote
     for (_, quote) in latest_quotes {
         match ImpliedVolatility::from_quote(&quote, risk_free_rate) {
             Ok(iv) => {
@@ -174,12 +152,10 @@ async fn main() -> Result<()> {
 
     info!("Successfully calculated {} implied volatilities", ivs.len());
 
-    // Step 8: Create volatility surface
     info!("Creating volatility surface");
 
     let surface = VolatilitySurface::new(symbol.to_string(), &ivs)?;
 
-    // Step 9: Plot volatility surface and smiles
     info!("Plotting volatility surface");
 
     let output_dir = Path::new("output");
@@ -187,12 +163,10 @@ async fn main() -> Result<()> {
         std::fs::create_dir(output_dir)?;
     }
 
-    // Plot the full volatility surface
     let surface_path = output_dir.join("volatility_surface.png");
     plot_volatility_surface(&surface, &surface_path)?;
     info!("Volatility surface saved to {:?}", surface_path);
 
-    // Plot volatility smile for the first expiration
     if !surface.expirations.is_empty() {
         let expiration = surface.expirations[0];
         let (strikes, vols) = surface.slice_by_expiration(expiration)?;


### PR DESCRIPTION
## Summary
- correct Alpaca REST endpoints
- expand historical bars/trades methods with required params
- add snapshot API helpers for options symbols and chains

## Testing
- `cargo fmt -- --check` *(fails: rustfmt component not installed)*
- `cargo check` *(fails: could not download crates due to network)*
- `cargo test` *(fails: could not download crates due to network)*